### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
         METADATA.update(SETUPTOOLS_METADATA)
         setuptools.setup(**METADATA)
     except ImportError:
-        print "Could not import setuptools, using distutils"
-        print "NOTE: You will need to install dependencies manualy" 
+        print ("Could not import setuptools, using distutils")
+        print ("NOTE: You will need to install dependencies manualy")
         import distutils.core
         distutils.core.setup(**METADATA)


### PR DESCRIPTION
fix the syntax around `print` statements so they will work with python3.6